### PR TITLE
fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 
+	* fix issue where setting file/piece priority would stop checking
 	* fix backwards compatibility to downloads without partfiles
 	* improve part-file related error messages
 	* fix reporting &redundant= in tracker announces

--- a/simulation/test_torrent_status.cpp
+++ b/simulation/test_torrent_status.cpp
@@ -87,16 +87,8 @@ TORRENT_TEST(status_timers)
 				TEST_EQUAL(st.last_scrape, -1);
 				TEST_EQUAL(st.time_since_upload, -1);
 
-				// checking the torrent counts as downloading
-				// eventually though, we've forgotten about it and go back to -1
-				if (since_start > 65000)
-				{
-					TEST_EQUAL(st.time_since_download, -1);
-				}
-				else
-				{
-					TEST_EQUAL(st.time_since_download, since_start);
-				}
+				// checking the torrent does not count as downloading
+				TEST_EQUAL(st.time_since_download, -1);
 			}
 			return false;
 		});

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -115,6 +115,26 @@ namespace libtorrent
 {
 	namespace {
 
+	bool is_downloading_state(int st)
+	{
+		switch (st)
+		{
+			case torrent_status::checking_files:
+			case torrent_status::allocating:
+			case torrent_status::checking_resume_data:
+				return false;
+			case torrent_status::downloading_metadata:
+			case torrent_status::downloading:
+			case torrent_status::finished:
+			case torrent_status::seeding:
+				return true;
+			default:
+				// unexpected state
+				TORRENT_ASSERT_VAL(false, st);
+				return false;
+		}
+	}
+
 	int root2(int x)
 	{
 		int ret = 0;
@@ -4368,23 +4388,26 @@ namespace {
 
 		remove_time_critical_piece(index, true);
 
-		if (is_finished()
-			&& m_state != torrent_status::finished
-			&& m_state != torrent_status::seeding)
+		if (is_downloading_state(m_state))
 		{
-			// torrent finished
-			// i.e. all the pieces we're interested in have
-			// been downloaded. Release the files (they will open
-			// in read only mode if needed)
-			finished();
-			// if we just became a seed, picker is now invalid, since it
-			// is deallocated by the torrent once it starts seeding
+			if (is_finished()
+				&& m_state != torrent_status::finished
+				&& m_state != torrent_status::seeding)
+			{
+				// torrent finished
+				// i.e. all the pieces we're interested in have
+				// been downloaded. Release the files (they will open
+				// in read only mode if needed)
+				finished();
+				// if we just became a seed, picker is now invalid, since it
+				// is deallocated by the torrent once it starts seeding
+			}
+
+			m_last_download = m_ses.session_time();
+
+			if (m_share_mode)
+				recalc_share_mode();
 		}
-
-		m_last_download = m_ses.session_time();
-
-		if (m_share_mode)
-			recalc_share_mode();
 	}
 
 	// this is called when the piece hash is checked as correct. Note
@@ -5793,6 +5816,15 @@ namespace {
 			// invalidate the iterator
 			++i;
 			p->update_interest();
+		}
+
+		if (!is_downloading_state(m_state))
+		{
+#ifndef TORRENT_DISABLE_LOGGING
+			debug_log("*** UPDATE_PEER_INTEREST [ skipping, state: %d ]"
+				, int(m_state));
+#endif
+			return;
 		}
 
 #ifndef TORRENT_DISABLE_LOGGING
@@ -8108,8 +8140,7 @@ namespace {
 			return false;
 		}
 
-		if ((m_state == torrent_status::checking_files
-			|| m_state == torrent_status::checking_resume_data)
+		if (!is_downloading_state(m_state)
 			&& valid_metadata())
 		{
 			p->disconnect(errors::torrent_not_ready, op_bittorrent);
@@ -8646,20 +8677,9 @@ namespace {
 		// to be in downloading state (which it will be set to shortly)
 //		INVARIANT_CHECK;
 
-		// workaround for torrent getting stuck in `downloading` state
-		if (!are_files_checked())
-			set_state(torrent_status::checking_files);
-
-		if (m_state == torrent_status::checking_resume_data
-			|| m_state == torrent_status::checking_files
-			|| m_state == torrent_status::allocating)
-		{
-#ifndef TORRENT_DISABLE_LOGGING
-			debug_log("*** RESUME_DOWNLOAD [ skipping, state: %d ]"
-				, int(m_state));
-#endif
-			return;
-		}
+		TORRENT_ASSERT(m_state != torrent_status::checking_resume_data
+			&& m_state != torrent_status::checking_files
+			&& m_state != torrent_status::allocating);
 
 		// we're downloading now, which means we're no longer in seed mode
 		if (m_seed_mode)
@@ -11947,29 +11967,6 @@ namespace {
 	void torrent::new_external_ip()
 	{
 		if (m_peer_list) m_peer_list->clear_peer_prio();
-	}
-
-	namespace
-	{
-		bool is_downloading_state(int st)
-		{
-			switch (st)
-			{
-				case torrent_status::checking_files:
-				case torrent_status::allocating:
-				case torrent_status::checking_resume_data:
-					return false;
-				case torrent_status::downloading_metadata:
-				case torrent_status::downloading:
-				case torrent_status::finished:
-				case torrent_status::seeding:
-					return true;
-				default:
-					// unexpected state
-					TORRENT_ASSERT_VAL(false, st);
-					return false;
-			}
-		}
 	}
 
 	void torrent::stop_when_ready(bool b)

--- a/test/test_checking.cpp
+++ b/test/test_checking.cpp
@@ -332,11 +332,10 @@ TORRENT_TEST(discrete_checking)
 		p.save_path = ".";
 		p.ti = ti;
 		torrent_handle tor1 = ses1.add_torrent(p, ec);
-		TEST_CHECK(wait_for_alert(ses1, torrent_finished_alert::alert_type, "checking file 0"));
+		// change the priority of a file while checking and make sure it doesn't interrupt the checking.
 		std::vector<int> prio(ti->num_files(), 0);
 		prio[2] = 1;
 		tor1.prioritize_files(prio);
-		TEST_CHECK(wait_for_alert(ses1, torrent_finished_alert::alert_type, "checking file 1"));
 		TEST_CHECK(wait_for_alert(ses1, torrent_checked_alert::alert_type, "torrent checked"));
 		TEST_CHECK(tor1.status(0).is_seeding);
 	}

--- a/test/test_torrent.cpp
+++ b/test/test_torrent.cpp
@@ -417,6 +417,8 @@ void test_queue(add_torrent_params p)
 		torrents.push_back(ses.add_torrent(p));
 	}
 
+	print_alerts(ses, "ses");
+
 	std::vector<int> pieces = torrents[5].piece_priorities();
 	std::vector<std::pair<int, int> > piece_prios;
 	for (int i = 0; i < int(pieces.size()); ++i) {
@@ -424,6 +426,8 @@ void test_queue(add_torrent_params p)
 	}
 	torrents[5].prioritize_pieces(piece_prios);
 	torrent_handle finished = torrents[5];
+
+	wait_for_alert(ses, torrent_finished_alert::alert_type, "ses");
 
 	// add_torrent should be ordered
 	TEST_EQUAL(finished.queue_position(), -1);


### PR DESCRIPTION
As far as I can tell, the underlying problem is that the checking is interrupted by changing the file priority, and also by ``we_have()`` when we check the last non-zero priority piece. Basically any call to ``set_state()`` during checking will interrupt it.

This patch make it not be interrupted, and always continue the checking.