### PR TITLE
make the patch smaller (and easier to merge into master)

### DIFF
--- a/include/libtorrent/torrent.hpp
+++ b/include/libtorrent/torrent.hpp
@@ -552,6 +552,7 @@ namespace libtorrent
 		void set_piece_deadline(int piece, int t, int flags);
 		void reset_piece_deadline(int piece);
 		void clear_time_critical();
+		void update_piece_priorities();
 
 		void status(torrent_status* st, boost::uint32_t flags);
 
@@ -1148,7 +1149,7 @@ namespace libtorrent
 
 		void ip_filter_updated();
 
-		void inc_stats_counter(int c, int value = 1) const;
+		void inc_stats_counter(int c, int value = 1);
 
 		// initialize the torrent_state structure passed to peer_list
 		// member functions. Don't forget to also call peers_erased()
@@ -1181,7 +1182,6 @@ namespace libtorrent
 		bool request_bandwidth_from_session(int channel) const;
 
 		void update_peer_interest(bool was_finished);
-		void update_piece_priorities();
 		void prioritize_udp_trackers();
 
 		void update_tracker_timer(time_point now);

--- a/src/disk_io_thread.cpp
+++ b/src/disk_io_thread.cpp
@@ -2019,6 +2019,8 @@ namespace libtorrent
 		add_job(j);
 	}
 
+	// TODO 3: take `prios` by value and move it into the disk job instead of
+	// copying it into a heap allocation
 	void disk_io_thread::async_set_file_priority(piece_manager* storage
 		, std::vector<boost::uint8_t> const& prios
 		, boost::function<void(disk_io_job const*)> const& handler)

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -400,7 +400,7 @@ namespace libtorrent
 		}
 	}
 
-	void torrent::inc_stats_counter(int c, int value) const
+	void torrent::inc_stats_counter(int c, int value)
 	{ m_ses.stats_counters().inc_stats_counter(c, value); }
 
 #if 0
@@ -2018,7 +2018,8 @@ namespace libtorrent
 
 		// in case file priorities were passed in via the add_torrent_params
 		// and also in the case of share mode, we need to update the priorities
-		if (std::find(m_file_priority.begin(), m_file_priority.end(), 0) != m_file_priority.end())
+		if (!m_file_priority.empty() && std::find(m_file_priority.begin()
+				, m_file_priority.end(), 0) != m_file_priority.end())
 		{
 			update_piece_priorities();
 		}
@@ -5656,6 +5657,7 @@ namespace {
 
 			for (int i = 0; i < std::min<int>(fs.num_files(), files.size()); ++i)
 			{
+				// initialize pad files to priority 0
 				if (files[i] > 0 && fs.pad_file_at(i))
 					files[i] = 0;
 				else if (files[i] > 7)
@@ -5678,30 +5680,31 @@ namespace {
 
 		boost::scoped_ptr<std::vector<boost::uint8_t> > p(j->buffer.priorities);
 
-		if (j->ret == piece_manager::no_error)
+		if (m_file_priority != *p)
 		{
-			TORRENT_ASSERT(!j->error);
 			m_file_priority = *p;
 			update_piece_priorities();
 		}
-		else
-		{
-			// in this case, some file priorities failed to get set
-			TORRENT_ASSERT(j->error);
-			TORRENT_ASSERT(!m_share_mode);
 
-			if (alerts().should_post<file_error_alert>())
-				alerts().emplace_alert<file_error_alert>(j->error.ec
-					, resolve_filename(j->error.file), j->error.operation_str(), get_handle());
+		if (!j->error) return;
 
-			set_error(j->error.ec, j->error.file);
-			pause();
-		}
+		// in this case, some file priorities failed to get set
+		TORRENT_ASSERT(j->error);
+		TORRENT_ASSERT(!m_share_mode);
+
+		if (alerts().should_post<file_error_alert>())
+			alerts().emplace_alert<file_error_alert>(j->error.ec
+				, resolve_filename(j->error.file), j->error.operation_str(), get_handle());
+
+		set_error(j->error.ec, j->error.file);
+		pause();
 	}
 
 	void torrent::prioritize_files(std::vector<int> const& files)
 	{
 		INVARIANT_CHECK;
+
+		if (is_seed()) return;
 
 		// store file priorities until we get the metadata
 		if (!valid_metadata())
@@ -5710,29 +5713,48 @@ namespace {
 			return;
 		}
 
+		// the vector need to have exactly one element for every file
+		// in the torrent
+		TORRENT_ASSERT(int(files.size()) == m_torrent_file->num_files());
+
 		std::vector<boost::uint8_t> const new_priority = fix_priorities(files, m_torrent_file->files());
 
-		if (!m_torrent_file->num_pieces() || is_seed() || new_priority == m_file_priority) { return; }
+		if (new_priority == m_file_priority)
+		{
+			return;
+		}
 
 		// storage may be NULL during shutdown
-		if (boost::shared_ptr<piece_manager> const tmp = m_storage)
+		if (m_torrent_file->num_pieces() > 0 && m_storage)
 		{
 			inc_refcount("file_priority");
-			m_ses.disk_thread().async_set_file_priority(tmp.get(), new_priority,
-				boost::bind(&torrent::on_file_priority, shared_from_this(), _1));
+			m_ses.disk_thread().async_set_file_priority(m_storage.get()
+				, new_priority, boost::bind(&torrent::on_file_priority, shared_from_this(), _1));
 		}
 	}
 
 	void torrent::set_file_priority(int index, int prio)
 	{
-		if (index < 0 || (valid_metadata() && index >= m_torrent_file->num_files())) { return; }
+		INVARIANT_CHECK;
 
-		// any unallocated slot is assumed to be 4
-		if (int(m_file_priority.size()) <= index && prio == 4) { return; }
+		if (is_seed()) return;
 
-		std::vector<int> file_priority(m_file_priority.begin(), m_file_priority.end());        
+		// setting file priority on a torrent that doesn't have metadata yet is
+		// similar to having passed in file priorities through add_torrent_params.
+		// we store the priorities in m_file_priority until we get the metadata
+		if (index < 0 || (valid_metadata() && index >= m_torrent_file->num_files()))
+		{
+			return;
+		}
+
+		if (prio < 0) prio = 0;
+		else if (prio > 7) prio = 7;
+
+		// TODO 3: don't make an unnecessary copy of a vector<int> here. stick to
+		// std::vector<uint8_t>
+		std::vector<int> file_priority(m_file_priority.begin(), m_file_priority.end());
 		file_priority.resize(std::max(int(file_priority.size()), index + 1), 4);
-		file_priority[index] = prio;        
+		file_priority[index] = prio;
 
 		prioritize_files(file_priority);
 	}
@@ -5764,8 +5786,11 @@ namespace {
 
 		files->assign(m_file_priority.begin(), m_file_priority.end());
 
-		if (!valid_metadata()) { return; }
-		
+		if (!valid_metadata())
+		{
+			return;
+		}
+
 		files->resize(m_torrent_file->num_files(), 4);
 	}
 

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -5684,12 +5684,13 @@ namespace {
 		{
 			m_file_priority = *p;
 			update_piece_priorities();
+			if (m_share_mode)
+				recalc_share_mode();
 		}
 
 		if (!j->error) return;
 
 		// in this case, some file priorities failed to get set
-		TORRENT_ASSERT(!m_share_mode);
 
 		if (alerts().should_post<file_error_alert>())
 			alerts().emplace_alert<file_error_alert>(j->error.ec

--- a/src/torrent.cpp
+++ b/src/torrent.cpp
@@ -1147,7 +1147,6 @@ namespace libtorrent
 			int const num_files = valid_metadata() ? m_torrent_file->num_files() : m_file_priority.size();
 			// in share mode, all pieces have their priorities initialized to 0
 			prioritize_files(std::vector<int>(num_files));
-			recalc_share_mode();
 		}
 	}
 

--- a/test/test_priority.cpp
+++ b/test/test_priority.cpp
@@ -394,8 +394,11 @@ TORRENT_TEST(no_metadata_file_prio)
 	torrent_handle h = ses.add_torrent(addp);
 
 	h.file_priority(0, 0);
+	// TODO 2: this should wait for an alert instead of just sleeping
+	test_sleep(100);
 	TEST_EQUAL(h.file_priority(0), 0);
 	h.file_priority(0, 1);
+	test_sleep(100);
 	TEST_EQUAL(h.file_priority(0), 1);
 
 	ses.remove_torrent(h);


### PR DESCRIPTION
I reverted some non-essential aspects of the patch. I think those are best applied to master instead of RC_1_1. I'm hoping this would make it simpler to forward port into master later